### PR TITLE
Speedy

### DIFF
--- a/blurry.cl
+++ b/blurry.cl
@@ -1,16 +1,18 @@
 __kernel void blurry(__global ushort* pixels, __global ushort* pixelsOut, int numRGBElements, int width, int height){
 
-  pixelsOut[0] = 0;
-  pixelsOut[1] = 0;
-  pixelsOut[2] = 0;
-  pixelsOut[numRGBElements - 1] = 0;
-  pixelsOut[numRGBElements - 2] = 0;
-  pixelsOut[numRGBElements - 3] = 0;
+  // pixelsOut[0] = 0;
+  // pixelsOut[1] = 0;
+  // pixelsOut[2] = 0;
+  // pixelsOut[numRGBElements - 1] = 0;
+  // pixelsOut[numRGBElements - 2] = 0;
+  // pixelsOut[numRGBElements - 3] = 0;
 
-  for( int i = 3; i < numRGBElements - 4 ; i += 1){
-    pixelsOut[i] = ((pixels[i - 3] * 0.45) + (pixels[i] * 0.45) + (pixels[i + 3] * 0.45)) ;
-    if(pixelsOut[i] > 255) pixelsOut[i] = 255;
+  // for( int i = 3; i < numRGBElements - 4 ; i += 1){
+  //   pixelsOut[i] = ((pixels[i - 3] * 0.45) + (pixels[i] * 0.45) + (pixels[i + 3] * 0.45)) ;
+  //   if(pixelsOut[i] > 255) pixelsOut[i] = 255;
+  //
+  // }
 
-  }
-
+  const int i = get_global_id(0);
+  pixelsOut[i] = ((pixels[i - 3] * 0.33) + (pixels[i] * 0.33) + (pixels[i + 3] * 0.33));
 }

--- a/blurry.cl
+++ b/blurry.cl
@@ -1,18 +1,4 @@
-__kernel void blurry(__global ushort* pixels, __global ushort* pixelsOut, int numRGBElements, int width, int height){
-
-  // pixelsOut[0] = 0;
-  // pixelsOut[1] = 0;
-  // pixelsOut[2] = 0;
-  // pixelsOut[numRGBElements - 1] = 0;
-  // pixelsOut[numRGBElements - 2] = 0;
-  // pixelsOut[numRGBElements - 3] = 0;
-
-  // for( int i = 3; i < numRGBElements - 4 ; i += 1){
-  //   pixelsOut[i] = ((pixels[i - 3] * 0.45) + (pixels[i] * 0.45) + (pixels[i + 3] * 0.45)) ;
-  //   if(pixelsOut[i] > 255) pixelsOut[i] = 255;
-  //
-  // }
-
+__kernel void blurry(__global unsigned char* pixels, __global unsigned char* pixelsOut, int numRGBElements, int width, int height){
   const int i = get_global_id(0);
-  pixelsOut[i] = ((pixels[i - 3] * 0.33) + (pixels[i] * 0.33) + (pixels[i + 3] * 0.33));
+  pixelsOut[i] = ((pixels[i - 3] * 0.333) + (pixels[i] * 0.333) + (pixels[i + 3] * 0.333));
 }

--- a/blurry.cl
+++ b/blurry.cl
@@ -1,4 +1,4 @@
-__kernel void blurry(__global int* pixels, __global int* pixelsOut, int numRGBElements, int width, int height){
+__kernel void blurry(__global ushort* pixels, __global ushort* pixelsOut, int numRGBElements, int width, int height){
 
   pixelsOut[0] = 0;
   pixelsOut[1] = 0;

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -135,7 +135,7 @@ NAN_METHOD(Blurry) {
   size_t global_item_size[1];
   size_t local_item_size[1];
 
-  global_item_size[0] = 2;
+  global_item_size[0] = numRGBElements;
   local_item_size[0] = 1;
 
   /* Execute OpenCL Kernel */

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -24,14 +24,6 @@ using Nan::Null;
 using Nan::To;
 
 NAN_METHOD(Blurry) {
-  // if(true){
-  //   printf("The size of an int is : %d \n", sizeof(int) );
-  //   printf("The size of a short unsigned int is : %d \n", sizeof(ushort));
-  //   ushort try1 = 255;
-  //   ushort try2 = 0;
-  //   printf("As a trial here are two unsigned short ints, from the bottom to top of the needed range: %d - %d \n", try2, try1);
-  //   // exit(0);
-  // }
 
   cl_device_id device_id = NULL;
   cl_context context = NULL;
@@ -44,8 +36,8 @@ NAN_METHOD(Blurry) {
   cl_uint ret_num_devices;
   cl_uint ret_num_platforms;
   cl_int ret;
-  ushort *outImg;
-  ushort *simpleArray;
+  unsigned char *outImg;
+  unsigned char *simpleArray;
 
   Local<Uint8Array> converter = info[0].As<Uint8Array>();
   Nan::TypedArrayContents<uint8_t> Arr(converter);
@@ -71,8 +63,8 @@ NAN_METHOD(Blurry) {
   }
 
   int numRGBElements = width * height * 3;
-  outImg = (ushort *)malloc(numRGBElements * sizeof(ushort));
-  simpleArray = (ushort *)malloc(numRGBElements * sizeof(ushort));
+  outImg = (unsigned char *)malloc(numRGBElements * sizeof(unsigned char));
+  simpleArray = (unsigned char *)malloc(numRGBElements * sizeof(unsigned char));
 
   for (int m = 0; m < numRGBElements; m++){
     simpleArray[m] = (*Arr)[m];
@@ -106,10 +98,10 @@ NAN_METHOD(Blurry) {
 
   /* Create Memory Buffer */
   memobjIn  = clCreateBuffer(context, CL_MEM_READ_WRITE,
-                               numRGBElements * sizeof(ushort), NULL, &ret);
+                               numRGBElements * sizeof(unsigned char), NULL, &ret);
 
   memobjOut = clCreateBuffer(context, CL_MEM_READ_WRITE,
-                               numRGBElements * sizeof(ushort), NULL, &ret);
+                               numRGBElements * sizeof(unsigned char), NULL, &ret);
 
   /* Create Kernel Program from the source */
   program = clCreateProgramWithSource(context, 1, (const char **)&source_str,
@@ -122,7 +114,7 @@ NAN_METHOD(Blurry) {
   kernel = clCreateKernel(program, "blurry", &ret);
 
   ret = clEnqueueWriteBuffer(command_queue, memobjIn, CL_TRUE, 0,
-                               numRGBElements * sizeof(ushort),
+                               numRGBElements * sizeof(unsigned char),
                                simpleArray, 0, NULL, NULL);
 
   /* Set OpenCL Kernel Parameters */
@@ -145,7 +137,7 @@ NAN_METHOD(Blurry) {
 
   /* Copy results from the memory buffer */
   ret = clEnqueueReadBuffer(command_queue, memobjOut, CL_TRUE, 0,
-              width * height * 3 * sizeof(ushort), (void *)outImg, 0, NULL, NULL);
+              width * height * 3 * sizeof(unsigned char), (void *)outImg, 0, NULL, NULL);
 
   /* Finalization */
   ret = clFlush(command_queue);

--- a/server/routes/content_routes.js
+++ b/server/routes/content_routes.js
@@ -13,37 +13,6 @@ var PixelStream = require('pixel-stream');
 var JPEGDecoder = require('jpg-stream/decoder');
 var JPEGEncoder = require('jpg-stream/encoder');
 var inherits = require('util').inherits;
-var allPixels = [];
-
-function MyPixelStream() {
-  PixelStream.apply(this, arguments);
-}
-
-inherits(MyPixelStream, PixelStream);
-
-MyPixelStream.prototype._writePixels = function(data, done) {
-  for (var i = 0; i < data.length; i++) {
-    allPixels.push(data[i]);
-  }
-  done();
-};
-
-MyPixelStream.prototype._end = function(done) {
-  var translatedPixels = new Int32Array(allPixels);
-  var newPix = transformBlur.blurry(translatedPixels, this.format.width, this.format.height);
-  var bufTrans = new Buffer(newPix.length);
-  for (var j = 0; j < translatedPixels.length; j++) {
-    bufTrans[j] = newPix[j];
-  }
-
-  this.push(bufTrans);
-  allPixels = null;
-  allPixels = [];
-  translatedPixels = null;
-  newPix = null;
-  bufTrans = null;
-  done();
-};
 
 var contentRouter = module.exports = exports = express.Router();
 
@@ -67,6 +36,45 @@ contentRouter.post('/newcontent', jwtAuth, jsonParser, (req, res) => {
   if (req.body.content.length > 16000000) {
     return res.status(500).json( { 'msg': 'Error: image too large' } );
   }
+  var allPixels = [];
+
+  function MyPixelStream() {
+    PixelStream.apply(this, arguments);
+  }
+
+  inherits(MyPixelStream, PixelStream);
+
+  MyPixelStream.prototype._writePixels = function(data, done) {
+    for (var i = 0; i < data.length; i++) {
+      allPixels.push(data[i]);
+    }
+    data = null;
+    done();
+  };
+
+  MyPixelStream.prototype._end = function(done) {
+    var translatedPixels = new Int32Array(allPixels);
+    allPixels = null;
+    allPixels = [];
+    try {
+      var newPix = transformBlur.blurry(translatedPixels, this.format.width, this.format.height);
+
+    } catch (e) {
+      console.log('Error in transforming the image: ', e);
+      return res.status(500).json( { msg: 'transform failure' } );
+    }
+    var bufferLoopLen = translatedPixels.length;
+    translatedPixels = null;
+    var bufTrans = new Buffer(newPix.length);
+    for (var j = 0; j < bufferLoopLen; j++) {
+      bufTrans[j] = newPix[j];
+    }
+
+    newPix = null;
+    this.push(bufTrans);
+    bufTrans = null;
+    done();
+  };
 
   var newContent = new Content();
   newContent.user_id = req.user._id;
@@ -74,15 +82,19 @@ contentRouter.post('/newcontent', jwtAuth, jsonParser, (req, res) => {
 
   if ( newContent.tOption === 'blur') {
     var tempBuffer = new Buffer(req.body.content.slice(23), 'base64');
+    var lenOfBodyContent = req.body.content.length;
+    req.body.content = null;
     var outArray = [];
     var myStream = Readable();
     var ws = Writable();
+
     ws._write = function(chunk, enc, next) {
       outArray.push(chunk);
       next();
     };
+
     ws.on('finish', function() {
-      var transfer = new Buffer(req.body.content.length - 23);
+      var transfer = new Buffer(lenOfBodyContent - 23);
       var i = 0;
       for (var k = 0; k < outArray.length; k++) {
         for (var l = 0; l < outArray[k].length; l++) {
@@ -92,7 +104,6 @@ contentRouter.post('/newcontent', jwtAuth, jsonParser, (req, res) => {
         }
       }
       outArray = null;
-      tempBuffer = null;
 
       newContent.content = 'data:image/jpeg;base64,';
       newContent.content += transfer.toString('base64');
@@ -105,13 +116,16 @@ contentRouter.post('/newcontent', jwtAuth, jsonParser, (req, res) => {
       });
       newContent = null;
     });
+
     try {
       myStream.push(tempBuffer);
       myStream.push(null);
+      tempBuffer = null;
       myStream.pipe(new JPEGDecoder())
       .pipe(new MyPixelStream())
       .pipe(new JPEGEncoder())
       .pipe(ws);
+      myStream = null;
     } catch (e) {
       return console.log('Error in processing image: ', e);
     }

--- a/server/routes/content_routes.js
+++ b/server/routes/content_routes.js
@@ -53,7 +53,7 @@ contentRouter.post('/newcontent', jwtAuth, jsonParser, (req, res) => {
   };
 
   MyPixelStream.prototype._end = function(done) {
-    var translatedPixels = new Int32Array(allPixels);
+    var translatedPixels = new Uint8Array(allPixels);
     allPixels = null;
     allPixels = [];
     try {


### PR DESCRIPTION
Updates and changes to speed up the blur function. Reduced the memory requirements by switching to arrays of unsigned chars in the c++ and opencl code. Still having issues with large files, but small ones are blurred and stored. Importantly, I tried setting the work dimension to the number of elements in the RGB array and had a big boost in speed. This initial setting has much room for improvement, but at least is using parallel processing!